### PR TITLE
메인페이지 썸네일 화면 구현

### DIFF
--- a/src/components/mainPage/category/CategoryList.tsx
+++ b/src/components/mainPage/category/CategoryList.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { CategoryListProps } from "./types";
+import { CATEGORIES } from "./constants";
+import { CategoryListContainer, CategoryListWrapper, CategoryButton } from "./styles";
+
+const CategoryList = ({ onCategoryChange, defaultSelected = "all" }: CategoryListProps) => {
+    const [selectedCategory, setSelectedCategory] = useState<string>(defaultSelected);
+
+    const handleCategoryClick = (categoryId: string) => {
+        setSelectedCategory(categoryId);
+        onCategoryChange?.(categoryId);
+    };
+
+    return (
+        <CategoryListContainer>
+            <CategoryListWrapper>
+                {CATEGORIES.map((category) => (
+                    <CategoryButton
+                        key={category.id}
+                        $isSelected={category.id === selectedCategory}
+                        onClick={() => handleCategoryClick(category.id)}
+                    >
+                        {category.name}
+                    </CategoryButton>
+                ))}
+            </CategoryListWrapper>
+        </CategoryListContainer>
+    );
+};
+
+export default CategoryList;

--- a/src/components/mainPage/category/constants.ts
+++ b/src/components/mainPage/category/constants.ts
@@ -1,0 +1,17 @@
+import { CategoryItemType } from "./types";
+
+export const CATEGORIES: CategoryItemType[] = [
+    { id: "all", name: "전체" },
+    { id: "music", name: "음악" },
+    { id: "news", name: "뉴스" },
+    { id: "game", name: "게임" },
+    { id: "sports", name: "스포츠" },
+    { id: "movie", name: "영화" },
+    { id: "animation", name: "애니메이션" },
+    { id: "live", name: "라이브" },
+    { id: "shopping", name: "쇼핑" },
+    { id: "etc", name: "기타" },
+    { id: "recent", name: "최근에 업로드된 동영상" },
+    { id: "watched", name: "감상한 동영상" },
+    { id: "recommended", name: "새로운 맞춤 동영상" }
+];

--- a/src/components/mainPage/category/styles.ts
+++ b/src/components/mainPage/category/styles.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+export const CategoryButton = styled.button<{ $isSelected: boolean }>`
+    padding: 6px 12px;
+    border: none;
+    border-radius: 8px;
+    background-color: ${({ $isSelected }) => 
+        $isSelected ? '#0f0f0f' : '#f2f2f2'};
+    color: ${({ $isSelected }) => 
+        $isSelected ? '#ffffff' : '#0f0f0f'};
+    font-size: 14px;
+    font-weight: ${({ $isSelected }) => ($isSelected ? "500" : "400")};
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.2s ease;
+
+    &:hover {
+        background-color: ${({ $isSelected }) => 
+            $isSelected ? '#0f0f0f' : '#e5e5e5'};
+    }
+
+    &:focus {
+        outline: none;
+    }
+`;
+
+export const CategoryListContainer = styled.div`
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    display: flex;
+    overflow-x: auto;
+    padding: 12px 0;
+    margin-bottom: 4px;
+    background-color: #fff;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+`;
+
+export const CategoryListWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 0 24px;
+    gap: 12px;
+`;

--- a/src/components/mainPage/category/types.ts
+++ b/src/components/mainPage/category/types.ts
@@ -1,0 +1,9 @@
+export interface CategoryItemType {
+    id: string;
+    name: string;
+}
+
+export interface CategoryListProps {
+    onCategoryChange?: (category: string) => void;
+    defaultSelected?: string;
+}

--- a/src/components/mainPage/videoCard/VideoPreviewPlayer.tsx
+++ b/src/components/mainPage/videoCard/VideoPreviewPlayer.tsx
@@ -114,7 +114,7 @@ const Container = styled.div`
     position: relative;
     width: 100%;
     height: 100%;
-    background: #000;
+    background: #f1f1f1;
     overflow: hidden;
     border-radius: 12px;
 `;
@@ -123,12 +123,14 @@ const Video = styled.video`
     width: 100%;
     height: 100%;
     object-fit: cover;
+    display: block;
 `;
 
 const Thumbnail = styled.img`
     width: 100%;
     height: 100%;
     object-fit: cover;
+    display: block;
 `;
 
 const LoadingOverlay = styled.div`

--- a/src/components/mainPage/videoGrid/styles.ts
+++ b/src/components/mainPage/videoGrid/styles.ts
@@ -2,37 +2,37 @@ import styled from 'styled-components';
 
 export const GridContainer = styled.div`
     display: grid;
-    gap: 4px;  
-    width: calc(100% - 120px); 
-    max-width: 1850px;  
+    gap: 16px;  
+    width: 100%; 
+    max-width: 2200px;  
     margin: 0 auto;
-    padding: 16px 0;
+    padding: 16px 24px;
     
-    @media (min-width: 2100px) {
+    @media (min-width: 2200px) {
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+    
+    @media (min-width: 2000px) and (max-width: 2199px) {
         grid-template-columns: repeat(6, minmax(0, 1fr));
     }
     
-    @media (min-width: 1850px) and (max-width: 2099px) {
+    @media (min-width: 1600px) and (max-width: 1999px) {
         grid-template-columns: repeat(5, minmax(0, 1fr));
     }
     
-    @media (min-width: 1500px) and (max-width: 1849px) {
+    @media (min-width: 1200px) and (max-width: 1599px) {
         grid-template-columns: repeat(4, minmax(0, 1fr));
-        width: calc(100% - 80px);
     }
     
-    @media (min-width: 1000px) and (max-width: 1499px) {
+    @media (min-width: 800px) and (max-width: 1199px) {
         grid-template-columns: repeat(3, minmax(0, 1fr));
-        width: calc(100% - 60px);
     }
     
-    @media (min-width: 600px) and (max-width: 999px) {
+    @media (min-width: 500px) and (max-width: 799px) {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        width: calc(100% - 32px);
     }
     
-    @media (max-width: 599px) {
+    @media (max-width: 499px) {
         grid-template-columns: 1fr;
-        width: calc(100% - 24px);
     }
 `;

--- a/src/mock/video.mock.ts
+++ b/src/mock/video.mock.ts
@@ -3,6 +3,12 @@ import { http, HttpResponse, delay } from "msw";
 import { Video, VideoListResponse } from "../types/video.type";
 import { baseURL } from "../utils/baseURL";
 
+const generateThumbnail = () => {
+    // 더 안정적인 Picsum API 사용
+    const randomId = faker.number.int({ min: 1, max: 1000 });
+    return `https://picsum.photos/id/${randomId}/1280/720`;  // 16:9 비율의 고정된 크기
+};
+
 const generateVideoTitle = (): string => {
     const types = ["MV", "Official Video", "Shorts", "Vlog", "리뷰", "튜토리얼", "하이라이트"];
     const subjects = [
@@ -38,7 +44,7 @@ const generateMockVideo = (): Video => {
         id: faker.string.uuid(),
         title: generateVideoTitle(),
         channel: generateChannelName(),
-        thumbnailUrl: `/api/placeholder/${faker.number.int({ min: 300, max: 400 })}/${faker.number.int({ min: 200, max: 300 })}`,
+        thumbnailUrl: generateThumbnail(),
         previewUrl: faker.helpers.maybe(
             () => `https://storage.googleapis.com/gtv-videos-bucket/sample/${faker.helpers.arrayElement([
                 'BigBuckBunny',

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,12 +1,14 @@
-// import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRef, useCallback } from "react";
 import { Video } from "@@types/video.type";
 import VideoCard from "../components/mainPage/videoCard/VideoCard";
+import CategoryList from "@components/mainPage/category/CategoryList";
 import styled from "styled-components";
 import { useVideos } from "@hooks/useVideos";
+import { useLayoutStore } from "@stores/layoutStore";
 
 const MainPage = () => {
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useVideos();
+    const { isDesktopSidebarOpen } = useLayoutStore();
 
     const observerRef = useRef<IntersectionObserver>();
     const loadingRef = useRef<HTMLDivElement>(null);
@@ -34,7 +36,8 @@ const MainPage = () => {
     );
 
     return (
-        <MainPageContainer>
+        <MainPageContainer $isSidebarOpen={isDesktopSidebarOpen}>
+            <CategoryList />
             <ScrollContainer>
                 <VideoGrid>
                     {data?.pages.map((page) => page.data?.map((video: Video) => (
@@ -52,20 +55,20 @@ const MainPage = () => {
     );
 };
 
-const MainPageContainer = styled.div`
+const MainPageContainer = styled.div<{ $isSidebarOpen: boolean }>`
     position: fixed;
-    top: 56px; /* 헤더 높이 */
-    left: 72px; /* 사이드바 너비 */
+    top: 56px;
+    left: ${({ $isSidebarOpen }) => ($isSidebarOpen ? '240px' : '72px')};
     right: 0;
     bottom: 0;
     z-index: 1;
+    transition: left 0.2s;
 `;
 
 const ScrollContainer = styled.div`
     width: 100%;
     height: 100%;
     overflow-y: auto;
-    padding: 24px;
     box-sizing: border-box;
 
     /* 스크롤바 스타일링 */
@@ -85,27 +88,37 @@ const ScrollContainer = styled.div`
 
 const VideoGrid = styled.div`
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: 20px;
-    width: 100%;
-
-    @media (min-width: 1850px) {
-        grid-template-columns: repeat(5, 1fr);
+    gap: 16px;  
+    width: 100%; 
+    max-width: 2200px;  
+    margin: 0 auto;
+    padding: 16px 24px;
+    
+    @media (min-width: 2200px) {
+        grid-template-columns: repeat(7, minmax(0, 1fr));
     }
-
-    @media (min-width: 1500px) and (max-width: 1849px) {
-        grid-template-columns: repeat(4, 1fr);
+    
+    @media (min-width: 2000px) and (max-width: 2199px) {
+        grid-template-columns: repeat(6, minmax(0, 1fr));
     }
-
-    @media (min-width: 1000px) and (max-width: 1499px) {
-        grid-template-columns: repeat(3, 1fr);
+    
+    @media (min-width: 1600px) and (max-width: 1999px) {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
     }
-
-    @media (min-width: 600px) and (max-width: 999px) {
-        grid-template-columns: repeat(2, 1fr);
+    
+    @media (min-width: 1200px) and (max-width: 1599px) {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
     }
-
-    @media (max-width: 599px) {
+    
+    @media (min-width: 800px) and (max-width: 1199px) {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+    
+    @media (min-width: 500px) and (max-width: 799px) {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    
+    @media (max-width: 499px) {
         grid-template-columns: 1fr;
     }
 `;


### PR DESCRIPTION
## 작업내역

- 유튜브 메인페이지: 기존 검정화면에서 실제 썸네일이 표시되게끔 구현

## 주요 변경 사항

-   `video.mock.ts` : 썸네일은 piscum API 사용
-  `VideoPreviewPlayer.tsx` : 스타일 수정
